### PR TITLE
1 add ntp service

### DIFF
--- a/supportFiles/installChroot.sh
+++ b/supportFiles/installChroot.sh
@@ -16,7 +16,7 @@ apt-get -y upgrade
 /bin/bash /customize.sh
 
 echo Install packages
-apt-get install -y --no-install-recommends linux-image-amd64 live-boot systemd-sysv systemd-resolved
+apt-get install -y --no-install-recommends linux-image-amd64 live-boot systemd-sysv systemd-resolved ntp
 
 echo Clean apt post-install
 apt-get clean
@@ -25,6 +25,8 @@ echo Enable systemd-networkd as network manager
 systemctl enable systemd-networkd
 echo Enable systemd-resolved as dns manager
 systemctl enable systemd-resolved
+echo Enable ntp
+systemctl enable ntp
 
 echo Set root password
 echo "root:toor" | chpasswd

--- a/supportFiles/installChroot.sh
+++ b/supportFiles/installChroot.sh
@@ -16,7 +16,7 @@ apt-get -y upgrade
 /bin/bash /customize.sh
 
 echo Install packages
-apt-get install -y --no-install-recommends linux-image-amd64 live-boot systemd-sysv systemd-resolved ntp
+apt-get install -y --no-install-recommends linux-image-amd64 live-boot systemd-sysv systemd-resolved systemd-timesyncd
 
 echo Clean apt post-install
 apt-get clean
@@ -25,8 +25,8 @@ echo Enable systemd-networkd as network manager
 systemctl enable systemd-networkd
 echo Enable systemd-resolved as dns manager
 systemctl enable systemd-resolved
-echo Enable ntp
-systemctl enable ntp
+echo Enable systemd-timesyncd
+systemctl enable systemd-timesyncd
 
 echo Set root password
 echo "root:toor" | chpasswd


### PR DESCRIPTION
Tested by removing a CMOS battery from a motherboard and deliberately setting the year to 2020.  After booting with the nano iso, the system clock eventually synced up after a minute. Initial sync was still out of sync by an hour though. May adjust the README if I get time to test more.